### PR TITLE
Allow large contracts on local networks

### DIFF
--- a/onchain/rollups/hardhat.config.ts
+++ b/onchain/rollups/hardhat.config.ts
@@ -47,10 +47,14 @@ const infuraNetwork = (
 
 const config: HardhatUserConfig = {
     networks: {
-        hardhat: mnemonic ? { accounts: { mnemonic } } : {},
+        hardhat: {
+            accounts: mnemonic ? { mnemonic } : undefined,
+            allowUnlimitedContractSize: true,
+        },
         localhost: {
             url: "http://localhost:8545",
             accounts: mnemonic ? { mnemonic } : undefined,
+            allowUnlimitedContractSize: true,
         },
         mainnet: infuraNetwork("mainnet", 1, 6283185),
         goerli: infuraNetwork("goerli", 5, 6283185),


### PR DESCRIPTION
## Description

After merging https://github.com/Ultrachess/contracts/pull/1 I noticed that deployment was failing when running against this repo. The problem is that some of the DeFi dependencies, in particular Uniswap V3, have large contracts that require `allowUnlimitedContractSize` set to true.

## How has this been tested?

Before, attempting to deploy the DeFi contracts gave the error:

```
Error: Transaction reverted: trying to deploy a contract whose code is too large
``

After, contracts deploy successfully.