### PR TITLE
ci: push to DockerHub on tag and always to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - v*
     branches:
-      - develop
+      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,16 +36,16 @@ jobs:
         with:
           images: |
             name=ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}
-            name=docker.io/${{ github.repository_owner }}/${{ inputs.image-name }},enable=${{ github.repository_owner == 'cartesi' }}
+            name=docker.io/${{ github.repository_owner }}/${{ inputs.image-name }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: |
             type=semver,pattern={{version}}
-            type=ref,event=branch,enable=${{ github.repository_owner != 'cartesi' }}
-            type=ref,event=pr,enable=${{ github.repository_owner != 'cartesi' }}
-            type=sha,format=long,enable=${{ github.repository_owner != 'cartesi' }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=long
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
-        if: ${{ github.repository_owner == 'cartesi' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
This changes the CI push strategy to always push to GHCR and only push to DockerHub on tags.

I think we still need to change how docker build is done, to do it in a single multi-stage build.
But this fixes a real problem.