### PR TITLE
fix(contracts): do not format `finish_epoch_reponse.json`

### DIFF
--- a/onchain/rollups/test/foundry/dapp/helper/update-proofs.sh
+++ b/onchain/rollups/test/foundry/dapp/helper/update-proofs.sh
@@ -57,9 +57,8 @@ runmachine() {
 }
 
 # Decode strings in epoch status from Base64 to hexadecimal
-# Format the output with jq so that git diffs are smoother
 b64to16() {
-    python3 -m b64to16 output/finish_epoch_response_64.json | jq > finish_epoch_response.json
+    python3 -m b64to16 output/finish_epoch_response_64.json > finish_epoch_response.json
 }
 
 # Generate Solidity libraries with proofs from epoch status


### PR DESCRIPTION
* We used to format the JSON returned by the machine with `jq` to make git diffs smoother (fewer changed lines). But since now we are not committing this file anymore, it no longer makes no sense to format it with `jq`. This has no impact on the behaviour of the proof generation system, as `jq` only changes formatting, not the data.