### PR TITLE
chore: make issue templates uniform

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,10 +1,9 @@
 ---
-name: 🐛 Bug Report
+name: 🐛 Bug report
 about: Something isn't working as expected
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
 ## 🙂 Expected behavior

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -4,7 +4,6 @@ about: Suggest a new feature or improvement
 title: ''
 labels: feature
 assignees: ''
-
 ---
 
 ## 📚 Context

--- a/.github/ISSUE_TEMPLATE/gas-optimization.md
+++ b/.github/ISSUE_TEMPLATE/gas-optimization.md
@@ -1,20 +1,21 @@
 ---
-name: Gas Optimization
-about: Template for solidity smart contract gas optimization
+name: ⛽ Gas optimization
+about: Reduce gas usage of smart contracts
 title: ''
-labels: ''
+labels: onchain
 assignees: ''
-
 ---
 
-## Steps
-- [ ] configure and run the [HardHat profiler](https://www.npmjs.com/package/hardhat-gas-reporter)
-- [ ] check the boxes in the checklist if they are applicable. Leave out those that are not applicable. It would be helpful to record the gas savings amount for modification steps.
-- [ ] create a PR to compare the original/current gas report, display the amount of gas savings of modification steps, discuss and comment.
-- [ ] you can use [this Python script](https://gist.github.com/guidanoli/b7566f54c437e0b0f28c4554d151286f) to ease the job of comparing Hardhat gas reports. It takes two Hardhat gas reports (before and after some change) and outputs a Markdown table comparing them. Other options are available.
+## 🚶 Steps
+
+- [ ] Configure and run the [HardHat profiler](https://www.npmjs.com/package/hardhat-gas-reporter)
+- [ ] Check the boxes in the checklist if they are applicable. Leave out those that are not applicable. It would be helpful to record the gas savings amount for modification steps.
+- [ ] Create a PR to compare the original/current gas report, display the amount of gas savings of modification steps, discuss and comment.
+- [ ] You can use [this Python script](https://gist.github.com/guidanoli/b7566f54c437e0b0f28c4554d151286f) to ease the job of comparing Hardhat gas reports. It takes two Hardhat gas reports (before and after some change) and outputs a Markdown table comparing them. Other options are available.
 - [ ] (optional) Learn more about [gas consumption components of deploying a contract](https://ethereum.stackexchange.com/questions/35539/what-is-the-real-price-of-deploying-a-contract-on-the-mainnet/37898), [more detailed analysis](https://hackernoon.com/costs-of-a-real-world-ethereum-contract-2033511b3214), and how to [reduce contract bytecode](https://medium.com/daox/avoiding-out-of-gas-error-in-large-ethereum-smart-contracts-18961b1fc0c6)
 
-## Checklist
+## 📝 Checklist
+
 - [ ] 1. Pack storage variables
 - [ ] 2. uint8 is not always cheaper than uint256
 - [ ] 3. Mappings are cheaper than Arrays
@@ -39,4 +40,4 @@ assignees: ''
 - [ ] 22. Using proxy patterns for mass deployment
 - [ ] 23. General logic/programming optimization
 
-Please refer to [this article](https://mudit.blog/solidity-gas-optimization-tips/) and [this article](https://blog.polymath.network/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size-c44580b218e6) for details regarding the checkpoints.
+Please refer to articles [(a)](https://mudit.blog/solidity-gas-optimization-tips/) and [(b)](https://blog.polymath.network/solidity-tips-and-tricks-to-save-gas-and-reduce-bytecode-size-c44580b218e6) for details regarding the checkpoints.

--- a/.github/ISSUE_TEMPLATE/smart-contract-audit.md
+++ b/.github/ISSUE_TEMPLATE/smart-contract-audit.md
@@ -1,13 +1,12 @@
 ---
-name: Smart Contract Audit
-about: Template for auditing smart contracts
+name: 🔍 Smart contract audit
+about: Detect vulnerabilities in smart contracts
 title: ''
-labels: ''
+labels: onchain
 assignees: ''
-
 ---
 
-## Vulnerabilities
+## 🚩 Vulnerabilities
 
 Listed below are some well documented vulnerabilities that affect smart contracts.
 You can find many others from the list of references.
@@ -57,7 +56,7 @@ You can find many others from the list of references.
 - [ ] Outdated Compiler Version [(SWC-102)](https://swcregistry.io/docs/SWC-102)
 - [ ] Floating Pragma [(SWC-103)](https://swcregistry.io/docs/SWC-103)
 
-## References
+## 📚 References
 
 Smart Contract Weakness Classification and Test Cases. https://swcregistry.io/
 

--- a/.github/ISSUE_TEMPLATE/technical-debt.md
+++ b/.github/ISSUE_TEMPLATE/technical-debt.md
@@ -1,10 +1,9 @@
 ---
-name: 🏗️ Technical Debt
+name: 🏗️ Technical debt
 about: Propose solutions to technical debts
 title: ''
 labels: refactor
 assignees: ''
-
 ---
 
 ## 📚 Context

--- a/.github/ISSUE_TEMPLATE/update-dependencies.md
+++ b/.github/ISSUE_TEMPLATE/update-dependencies.md
@@ -1,10 +1,9 @@
 ---
-name: ⬆️ Update Dependencies
-about: Checklist when updating dependencies
+name: ⬆️  Dependency bump
+about: Checklist for bumping dependencies
 title: ''
 labels: chore
 assignees: ''
-
 ---
 
 ## 📚 Context
@@ -13,7 +12,7 @@ On-chain or Off-chain?
 
 ## 📈 Subtasks
 
-- [ ] Update major versions in `cargo.toml` and/or `packages.json`.
+- [ ] Update major versions in `Cargo.toml` and/or `packages.json`.
 - [ ] If an update requires major work, create the corresponding issue.
-- [ ] Update the dependencies in the lock file (`cargo.lock` and/or `yarn.lock`).
+- [ ] Update the dependencies in the lock file (`Cargo.lock` and/or `yarn.lock`).
 - [ ] Verify whether everything is working as expected.


### PR DESCRIPTION
* Capitalize only the first word in the issue template name
* Remove empty line before second `-------`
* Add emojis and labels to old issue templates
* Formatting changes to `gas-optimization.md`
* Rename "Update dependencies" ➡️ "Dependency bump" (to make it consistent with the other issue templates, which are not named after actions like "update this", or "report that")