### PR TITLE
Feature/rm closed pr images

### DIFF
--- a/.github/workflows/rm-closed-pr-images.yml
+++ b/.github/workflows/rm-closed-pr-images.yml
@@ -1,0 +1,34 @@
+name: Remove docker images for stale/closed PR(s).
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+jobs:
+  cleanup:
+    name: Cleanup ghcr.io/cartesi/${{ matrix.image }}:pr-${{ github.event.number }} image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        image:
+          - deployments
+          - rollups-advance-runner
+          - rollups-cli
+          - rollups-dispatcher
+          - rollups-graphql-server
+          - rollups-hardhat
+          - rollups-indexer
+          - rollups-inspect-server
+          - rollups-state-server
+    steps:
+      - uses: vlaurin/action-ghcr-prune@v0.5.0
+        with:
+          organization: cartesi
+          container: ${{ matrix.image }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prune-untagged: true
+          keep-last: 0
+          prune-tags-regexes: |
+            ^pr-${{ github.event.number }}$


### PR DESCRIPTION
The last 2 commits from this PR should be removed before merging.

The last one adds the `:pr-46` to the list of tags to be removed, just to test the dry-run using this value to remove.

The following links are evidence of the `cartesi/deployments:pr-46` image that would be pruned.

- https://github.com/cartesi/rollups/actions/runs/5094412947/jobs/9158188117#step:2:521
- https://github.com/cartesi/rollups/pkgs/container/deployments/94691370?tag=pr-46