### PR TITLE
Add `Authority` factory

### DIFF
--- a/onchain/rollups/contracts/consensus/authority/AuthorityFactory.sol
+++ b/onchain/rollups/contracts/consensus/authority/AuthorityFactory.sol
@@ -1,0 +1,59 @@
+// Copyright Cartesi Pte. Ltd.
+
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+pragma solidity ^0.8.8;
+
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+
+import {IAuthorityFactory} from "./IAuthorityFactory.sol";
+import {Authority} from "./Authority.sol";
+
+/// @title Authority Factory
+/// @notice Allows anyone to reliably deploy a new `Authority` contract.
+contract AuthorityFactory is IAuthorityFactory {
+    function newAuthority(
+        address _authorityOwner
+    ) external override returns (Authority) {
+        Authority authority = new Authority(_authorityOwner);
+
+        emit AuthorityCreated(_authorityOwner, authority);
+
+        return authority;
+    }
+
+    function newAuthority(
+        address _authorityOwner,
+        bytes32 _salt
+    ) external override returns (Authority) {
+        Authority authority = new Authority{salt: _salt}(_authorityOwner);
+
+        emit AuthorityCreated(_authorityOwner, authority);
+
+        return authority;
+    }
+
+    function calculateAuthorityAddress(
+        address _authorityOwner,
+        bytes32 _salt
+    ) external view override returns (address) {
+        return
+            Create2.computeAddress(
+                _salt,
+                keccak256(
+                    abi.encodePacked(
+                        type(Authority).creationCode,
+                        abi.encode(_authorityOwner)
+                    )
+                )
+            );
+    }
+}

--- a/onchain/rollups/contracts/consensus/authority/IAuthorityFactory.sol
+++ b/onchain/rollups/contracts/consensus/authority/IAuthorityFactory.sol
@@ -1,0 +1,55 @@
+// Copyright Cartesi Pte. Ltd.
+
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+pragma solidity ^0.8.8;
+
+import {Authority} from "./Authority.sol";
+
+/// @title Authority Factory interface
+interface IAuthorityFactory {
+    // Events
+
+    /// @notice A new authority was deployed.
+    /// @param authorityOwner The initial authority owner
+    /// @param authority The authority
+    /// @dev MUST be triggered on a successful call to `newAuthority`.
+    event AuthorityCreated(address authorityOwner, Authority authority);
+
+    // Permissionless functions
+
+    /// @notice Deploy a new authority.
+    /// @param _authorityOwner The initial authority owner
+    /// @return The authority
+    /// @dev On success, MUST emit an `AuthorityCreated` event.
+    function newAuthority(address _authorityOwner) external returns (Authority);
+
+    /// @notice Deploy a new authority deterministically.
+    /// @param _authorityOwner The initial authority owner
+    /// @param _salt The salt used to deterministically generate the authority address
+    /// @return The authority
+    /// @dev On success, MUST emit an `AuthorityCreated` event.
+    function newAuthority(
+        address _authorityOwner,
+        bytes32 _salt
+    ) external returns (Authority);
+
+    /// @notice Calculate the address of an authority to be deployed deterministically.
+    /// @param _authorityOwner The initial authority owner
+    /// @param _salt The salt used to deterministically generate the authority address
+    /// @return The deterministic authority address
+    /// @dev Beware that only the `newAuthority` function with the `_salt` parameter
+    ///      is able to deterministically deploy an authority.
+    function calculateAuthorityAddress(
+        address _authorityOwner,
+        bytes32 _salt
+    ) external view returns (address);
+}

--- a/onchain/rollups/deploy/02_factory.ts
+++ b/onchain/rollups/deploy/02_factory.ts
@@ -28,6 +28,7 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
     const { Bitmask, MerkleV2 } = await deployments.all();
 
+    await deployments.deploy("AuthorityFactory", opts);
     await deployments.deploy("CartesiDAppFactory", {
         ...opts,
         libraries: {

--- a/onchain/rollups/test/foundry/consensus/authority/AuthorityFactory.t.sol
+++ b/onchain/rollups/test/foundry/consensus/authority/AuthorityFactory.t.sol
@@ -1,0 +1,106 @@
+// Copyright Cartesi Pte. Ltd.
+
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+/// @title Authority Factory Test
+pragma solidity ^0.8.8;
+
+import {Test} from "forge-std/Test.sol";
+import {AuthorityFactory} from "contracts/consensus/authority/AuthorityFactory.sol";
+import {Authority} from "contracts/consensus/authority/Authority.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+contract AuthorityFactoryTest is Test {
+    AuthorityFactory factory;
+
+    // event emitted in the factory
+    event AuthorityCreated(address authorityOwner, Authority authority);
+
+    function setUp() public {
+        factory = new AuthorityFactory();
+    }
+
+    function testNewAuthority(address _authorityOwner) public {
+        vm.assume(_authorityOwner != address(0));
+
+        vm.recordLogs();
+
+        Authority authority = factory.newAuthority(_authorityOwner);
+
+        testNewAuthorityAux(_authorityOwner, authority);
+    }
+
+    function testNewAuthorityAux(
+        address _authorityOwner,
+        Authority _authority
+    ) internal {
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        uint256 numOfAuthorityCreated;
+
+        for (uint256 i; i < entries.length; ++i) {
+            Vm.Log memory entry = entries[i];
+
+            if (
+                entry.emitter == address(factory) &&
+                entry.topics[0] == AuthorityCreated.selector
+            ) {
+                ++numOfAuthorityCreated;
+
+                address a;
+                address b;
+
+                (a, b) = abi.decode(entry.data, (address, address));
+
+                assertEq(_authorityOwner, a);
+                assertEq(address(_authority), b);
+            }
+        }
+
+        assertEq(numOfAuthorityCreated, 1);
+
+        // call to check authority's owner
+        assertEq(_authority.owner(), _authorityOwner);
+    }
+
+    function testNewAuthorityDeterministic(
+        address _authorityOwner,
+        bytes32 _salt
+    ) public {
+        vm.assume(_authorityOwner != address(0));
+
+        address precalculatedAddress = factory.calculateAuthorityAddress(
+            _authorityOwner,
+            _salt
+        );
+
+        vm.recordLogs();
+
+        Authority authority = factory.newAuthority(_authorityOwner, _salt);
+
+        testNewAuthorityAux(_authorityOwner, authority);
+
+        // Precalculated address must match actual address
+        assertEq(precalculatedAddress, address(authority));
+
+        precalculatedAddress = factory.calculateAuthorityAddress(
+            _authorityOwner,
+            _salt
+        );
+
+        // Precalculated address must STILL match actual address
+        assertEq(precalculatedAddress, address(authority));
+
+        // Cannot deploy an authority with the same salt twice
+        vm.expectRevert();
+        factory.newAuthority(_authorityOwner, _salt);
+    }
+}


### PR DESCRIPTION
resolves cartesi/rollups-contracts#25 
Changes:
* Add a AuthorityFactory (and interface) smart contract to deploy Authority contracts.
* Add tests to AuthorityFactory.

TODO:
* Add tests for emitted events.
* Generate output proofs.