### PR TITLE
fix(onchain): change deployments image to rollups-deployments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,5 +192,5 @@ jobs:
     uses: ./.github/workflows/docker.yml
     with:
       target: deployments
-      image-name: deployments
+      image-name: rollups-deployments
     secrets: inherit


### PR DESCRIPTION
Naming was correct in `docker-bake.override.hcl` but not in the CI