### PR TITLE
Add `AuthorityHistoryPairFactory`

### DIFF
--- a/onchain/rollups/contracts/consensus/authority/AuthorityHistoryPairFactory.sol
+++ b/onchain/rollups/contracts/consensus/authority/AuthorityHistoryPairFactory.sol
@@ -1,0 +1,112 @@
+// Copyright Cartesi Pte. Ltd.
+
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+pragma solidity ^0.8.8;
+
+import {IAuthorityHistoryPairFactory} from "./IAuthorityHistoryPairFactory.sol";
+import {Authority} from "./Authority.sol";
+import {IAuthorityFactory} from "./IAuthorityFactory.sol";
+import {History} from "../../history/History.sol";
+import {IHistoryFactory} from "../../history/IHistoryFactory.sol";
+
+/// @title Authority-History Pair Factory
+/// @notice Allows anyone to reliably deploy a new Authority-History pair.
+contract AuthorityHistoryPairFactory is IAuthorityHistoryPairFactory {
+    IAuthorityFactory immutable authorityFactory;
+    IHistoryFactory immutable historyFactory;
+
+    /// @notice Constructs the factory.
+    /// @param _authorityFactory The `Authority` factory
+    /// @param _historyFactory The `History` factory
+    constructor(
+        IAuthorityFactory _authorityFactory,
+        IHistoryFactory _historyFactory
+    ) {
+        authorityFactory = _authorityFactory;
+        historyFactory = _historyFactory;
+
+        emit AuthorityHistoryPairFactoryCreated(
+            _authorityFactory,
+            _historyFactory
+        );
+    }
+
+    function getAuthorityFactory()
+        external
+        view
+        override
+        returns (IAuthorityFactory)
+    {
+        return authorityFactory;
+    }
+
+    function getHistoryFactory()
+        external
+        view
+        override
+        returns (IHistoryFactory)
+    {
+        return historyFactory;
+    }
+
+    function newAuthorityHistoryPair(
+        address _authorityOwner
+    ) external override returns (Authority authority_, History history_) {
+        authority_ = authorityFactory.newAuthority(address(this));
+        history_ = historyFactory.newHistory(address(authority_));
+
+        authority_.setHistory(history_);
+        authority_.transferOwnership(_authorityOwner);
+    }
+
+    function newAuthorityHistoryPair(
+        address _authorityOwner,
+        bytes32 _salt
+    ) external override returns (Authority authority_, History history_) {
+        _salt = calculateCompoundSalt(_authorityOwner, _salt);
+
+        authority_ = authorityFactory.newAuthority(address(this), _salt);
+        history_ = historyFactory.newHistory(address(authority_), _salt);
+
+        authority_.setHistory(history_);
+        authority_.transferOwnership(_authorityOwner);
+    }
+
+    function calculateAuthorityHistoryAddressPair(
+        address _authorityOwner,
+        bytes32 _salt
+    )
+        external
+        view
+        override
+        returns (address authorityAddress_, address historyAddress_)
+    {
+        _salt = calculateCompoundSalt(_authorityOwner, _salt);
+
+        authorityAddress_ = authorityFactory.calculateAuthorityAddress(
+            address(this),
+            _salt
+        );
+
+        historyAddress_ = historyFactory.calculateHistoryAddress(
+            authorityAddress_,
+            _salt
+        );
+    }
+
+    function calculateCompoundSalt(
+        address _authorityOwner,
+        bytes32 _salt
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(_authorityOwner, _salt));
+    }
+}

--- a/onchain/rollups/contracts/consensus/authority/IAuthorityHistoryPairFactory.sol
+++ b/onchain/rollups/contracts/consensus/authority/IAuthorityHistoryPairFactory.sol
@@ -1,0 +1,72 @@
+// Copyright Cartesi Pte. Ltd.
+
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+pragma solidity ^0.8.8;
+
+import {Authority} from "./Authority.sol";
+import {IAuthorityFactory} from "./IAuthorityFactory.sol";
+import {History} from "../../history/History.sol";
+import {IHistoryFactory} from "../../history/IHistoryFactory.sol";
+
+/// @title Authority-History Pair Factory interface
+interface IAuthorityHistoryPairFactory {
+    // Events
+
+    /// @notice The factory was created.
+    /// @param authorityFactory The underlying `Authority` factory
+    /// @param historyFactory The underlying `History` factory
+    /// @dev MUST be emitted on construction.
+    event AuthorityHistoryPairFactoryCreated(
+        IAuthorityFactory authorityFactory,
+        IHistoryFactory historyFactory
+    );
+
+    // Permissionless functions
+
+    /// @notice Get the factory used to deploy `Authority` contracts
+    /// @return The `Authority` factory
+    function getAuthorityFactory() external view returns (IAuthorityFactory);
+
+    /// @notice Get the factory used to deploy `History` contracts
+    /// @return The `History` factory
+    function getHistoryFactory() external view returns (IHistoryFactory);
+
+    /// @notice Deploy a new authority-history pair.
+    /// @param _authorityOwner The initial authority owner
+    /// @return The authority
+    /// @return The history
+    function newAuthorityHistoryPair(
+        address _authorityOwner
+    ) external returns (Authority, History);
+
+    /// @notice Deploy a new authority-history pair deterministically.
+    /// @param _authorityOwner The initial authority owner
+    /// @param _salt The salt used to deterministically generate the authority-history pair address
+    /// @return The authority
+    /// @return The history
+    function newAuthorityHistoryPair(
+        address _authorityOwner,
+        bytes32 _salt
+    ) external returns (Authority, History);
+
+    /// @notice Calculate the address of an authority-history pair to be deployed deterministically.
+    /// @param _authorityOwner The initial authority owner
+    /// @param _salt The salt used to deterministically generate the authority-history address pair
+    /// @return The deterministic authority address
+    /// @return The deterministic history address
+    /// @dev Beware that only the `newAuthorityHistoryPair` function with the `_salt` parameter
+    ///      is able to deterministically deploy an authority-history pair.
+    function calculateAuthorityHistoryAddressPair(
+        address _authorityOwner,
+        bytes32 _salt
+    ) external view returns (address, address);
+}

--- a/onchain/rollups/deploy/02_factory.ts
+++ b/onchain/rollups/deploy/02_factory.ts
@@ -28,8 +28,14 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
     const { Bitmask, MerkleV2 } = await deployments.all();
 
-    await deployments.deploy("AuthorityFactory", opts);
-    await deployments.deploy("HistoryFactory", opts);
+    const AuthorityFactory = await deployments.deploy("AuthorityFactory", opts);
+    const HistoryFactory = await deployments.deploy("HistoryFactory", opts);
+
+    await deployments.deploy("AuthorityHistoryPairFactory", {
+        ...opts,
+        args: [AuthorityFactory.address, HistoryFactory.address],
+    });
+
     await deployments.deploy("CartesiDAppFactory", {
         ...opts,
         libraries: {

--- a/onchain/rollups/test/foundry/consensus/authority/AuthorityHistoryPairFactory.t.sol
+++ b/onchain/rollups/test/foundry/consensus/authority/AuthorityHistoryPairFactory.t.sol
@@ -1,0 +1,183 @@
+// Copyright Cartesi Pte. Ltd.
+
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+/// @title Authority-History Pair Factory Test
+pragma solidity ^0.8.8;
+
+import {Test} from "forge-std/Test.sol";
+import {AuthorityHistoryPairFactory} from "contracts/consensus/authority/AuthorityHistoryPairFactory.sol";
+import {IAuthorityFactory} from "contracts/consensus/authority/IAuthorityFactory.sol";
+import {AuthorityFactory} from "contracts/consensus/authority/AuthorityFactory.sol";
+import {Authority} from "contracts/consensus/authority/Authority.sol";
+import {IHistoryFactory} from "contracts/history/IHistoryFactory.sol";
+import {HistoryFactory} from "contracts/history/HistoryFactory.sol";
+import {History} from "contracts/history/History.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+contract AuthorityFactoryTest is Test {
+    AuthorityFactory authorityFactory;
+    HistoryFactory historyFactory;
+    AuthorityHistoryPairFactory factory;
+
+    event AuthorityHistoryPairFactoryCreated(
+        IAuthorityFactory authorityFactory,
+        IHistoryFactory historyFactory
+    );
+
+    event AuthorityCreated(address authorityOwner, Authority authority);
+
+    event HistoryCreated(address historyOwner, History history);
+
+    function setUp() public {
+        authorityFactory = new AuthorityFactory();
+        historyFactory = new HistoryFactory();
+        factory = new AuthorityHistoryPairFactory(
+            authorityFactory,
+            historyFactory
+        );
+    }
+
+    function testFactoryCreation() public {
+        vm.recordLogs();
+
+        factory = new AuthorityHistoryPairFactory(
+            authorityFactory,
+            historyFactory
+        );
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        uint256 numOfFactoryCreated;
+
+        for (uint256 i; i < entries.length; ++i) {
+            Vm.Log memory entry = entries[i];
+
+            if (
+                entry.emitter == address(factory) &&
+                entry.topics[0] == AuthorityHistoryPairFactoryCreated.selector
+            ) {
+                ++numOfFactoryCreated;
+
+                address a;
+                address b;
+
+                (a, b) = abi.decode(entry.data, (address, address));
+
+                assertEq(address(authorityFactory), a);
+                assertEq(address(historyFactory), b);
+            }
+        }
+
+        assertEq(numOfFactoryCreated, 1);
+
+        assertEq(
+            address(factory.getAuthorityFactory()),
+            address(authorityFactory)
+        );
+        assertEq(address(factory.getHistoryFactory()), address(historyFactory));
+    }
+
+    function testNewAuthorityHistoryPair(address _authorityOwner) public {
+        vm.assume(_authorityOwner != address(0));
+
+        vm.recordLogs();
+
+        (Authority authority, History history) = factory
+            .newAuthorityHistoryPair(_authorityOwner);
+
+        testNewAuthorityHistoryPairAux(_authorityOwner, authority, history);
+    }
+
+    function testNewAuthorityHistoryPairAux(
+        address _authorityOwner,
+        Authority _authority,
+        History _history
+    ) internal {
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        uint256 numOfAuthorityCreated;
+        uint256 numOfHistoryCreated;
+
+        for (uint256 i; i < entries.length; ++i) {
+            Vm.Log memory entry = entries[i];
+
+            if (
+                entry.emitter == address(authorityFactory) &&
+                entry.topics[0] == AuthorityCreated.selector
+            ) {
+                ++numOfAuthorityCreated;
+
+                address a;
+                address b;
+
+                (a, b) = abi.decode(entry.data, (address, address));
+
+                assertEq(address(factory), a);
+                assertEq(address(_authority), b);
+            }
+
+            if (
+                entry.emitter == address(historyFactory) &&
+                entry.topics[0] == HistoryCreated.selector
+            ) {
+                ++numOfHistoryCreated;
+
+                address a;
+                address b;
+
+                (a, b) = abi.decode(entry.data, (address, address));
+
+                assertEq(address(_authority), a);
+                assertEq(address(_history), b);
+            }
+        }
+
+        assertEq(numOfAuthorityCreated, 1);
+        assertEq(numOfHistoryCreated, 1);
+
+        assertEq(address(_authority.owner()), _authorityOwner);
+        assertEq(address(_authority.getHistory()), address(_history));
+        assertEq(address(_history.owner()), address(_authority));
+    }
+
+    function testNewAuthorityHistoryPairDeterministic(
+        address _authorityOwner,
+        bytes32 _salt
+    ) public {
+        vm.assume(_authorityOwner != address(0));
+
+        (address authorityAddress, address historyAddress) = factory
+            .calculateAuthorityHistoryAddressPair(_authorityOwner, _salt);
+
+        vm.recordLogs();
+
+        (Authority authority, History history) = factory
+            .newAuthorityHistoryPair(_authorityOwner, _salt);
+
+        testNewAuthorityHistoryPairAux(_authorityOwner, authority, history);
+
+        // Precalculated addresses must match actual addresses
+        assertEq(authorityAddress, address(authority));
+        assertEq(historyAddress, address(history));
+
+        (authorityAddress, historyAddress) = factory
+            .calculateAuthorityHistoryAddressPair(_authorityOwner, _salt);
+
+        // Precalculated addresses must STILL match actual addresses
+        assertEq(authorityAddress, address(authority));
+        assertEq(historyAddress, address(history));
+
+        // Cannot deploy an authority-history pair with the same salt twice
+        vm.expectRevert();
+        factory.newAuthorityHistoryPair(_authorityOwner, _salt);
+    }
+}


### PR DESCRIPTION
Adds interface, implementation and tests.

Closes cartesi/rollups-contracts#29.