### PR TITLE
Feature/bump to debian bookworm

### DIFF
--- a/offchain/Dockerfile
+++ b/offchain/Dockerfile
@@ -12,7 +12,7 @@
 
 # syntax=docker.io/docker/dockerfile:1.4
 # deps install
-FROM rust:1.67.0-bullseye AS chef
+FROM rust:1.67.0-bookworm AS chef
 
 ENV CARGO_REGISTRIES_CARTESI_INDEX=https://github.com/cartesi/crates-index
 RUN rustup component add rustfmt
@@ -59,7 +59,7 @@ FROM builder as graphql_server_build
 RUN cargo build --release --bin graphql-server
 
 # define runtime image
-FROM debian:bullseye-20230522-slim as runtime
+FROM debian:bookworm-20230612-slim as runtime
 RUN addgroup --system --gid 102 cartesi && \
     adduser --system --uid 102 --ingroup cartesi --disabled-login --no-create-home --home /nonexistent --gecos "cartesi user" --shell /bin/false cartesi
 RUN mkdir -p /var/opt/cartesi

--- a/offchain/Dockerfile
+++ b/offchain/Dockerfile
@@ -58,10 +58,6 @@ RUN PATH="$PATH:$HOME/.local/bin" cargo build --release --bin advance-runner
 FROM builder as graphql_server_build
 RUN cargo build --release --bin graphql-server
 
-# grpc readiness probe
-FROM golang:1.19.0-bullseye as grpc_health_probe
-RUN go install github.com/grpc-ecosystem/grpc-health-probe@v0.4.11
-
 # define runtime image
 FROM debian:bullseye-20230522-slim as runtime
 RUN addgroup --system --gid 102 cartesi && \
@@ -78,7 +74,6 @@ apt-get update
 DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends ca-certificates
 rm -rf /var/lib/apt/lists/*
 EOF
-COPY --from=grpc_health_probe /go/bin/grpc-health-probe /usr/local/bin
 COPY --from=state_server_build /usr/src/app/offchain/target/release/rollups_state_server /opt/cartesi/bin/rollups_state_server
 USER cartesi
 ENTRYPOINT ["/opt/cartesi/bin/rollups_state_server"]

--- a/offchain/Dockerfile
+++ b/offchain/Dockerfile
@@ -12,7 +12,7 @@
 
 # syntax=docker.io/docker/dockerfile:1.4
 # deps install
-FROM rust:1.67.0-bookworm AS chef
+FROM rust:1.70.0-bookworm AS chef
 
 ENV CARGO_REGISTRIES_CARTESI_INDEX=https://github.com/cartesi/crates-index
 RUN rustup component add rustfmt


### PR DESCRIPTION
This PR will make changed to the offchain/Dockerfile to:

- remove `grpc_health_probe` from state-server image;
- update debian base image to bookworm;
- update rust to 1.70.0.