### PR TITLE
fix(dispatcher): not finish empty epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] 2023-06-14
+
+### Changed
+
+- Fixed dispatcher to not finish empty epoch
+
 ## [0.9.0] 2023-05-19
 
 ### Added
@@ -179,6 +185,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Specific ERC-20 Portal
 - Deprecated mock contracts
 
+[0.9.1]: https://github.com/cartesi/rollups/releases/tag/v0.9.1
 [0.9.0]: https://github.com/cartesi/rollups/releases/tag/v0.9.0
 [0.8.2]: https://github.com/cartesi/rollups/releases/tag/v0.8.2
 [0.8.1]: https://github.com/cartesi/rollups/releases/tag/v0.8.1

--- a/offchain/dispatcher/src/drivers/machine.rs
+++ b/offchain/dispatcher/src/drivers/machine.rs
@@ -155,13 +155,13 @@ mod tests {
     #[tokio::test]
     async fn process_input_at_finish_epoch() {
         let rollup_status = RollupStatus {
-            inputs_sent_count: 0,
+            inputs_sent_count: 1,
             last_event_is_finish_epoch: false,
         };
         let input_timestamps = vec![5];
         let send_interactions = vec![
-            SendInteraction::FinishedEpoch(0),
-            SendInteraction::EnqueuedInput(0),
+            SendInteraction::FinishedEpoch(1),
+            SendInteraction::EnqueuedInput(1),
         ];
         test_process_input(rollup_status, input_timestamps, send_interactions)
             .await;
@@ -380,5 +380,22 @@ mod tests {
             .await;
         assert!(result.is_ok());
         broker.assert_send_interactions(vec![]);
+    }
+
+    #[tokio::test]
+    async fn react_with_inputs_after_first_epoch_length() {
+        let block = mock::new_block(5);
+        let rollup_status = RollupStatus {
+            inputs_sent_count: 0,
+            last_event_is_finish_epoch: false,
+        };
+        let input_timestamps = vec![7, 8];
+        let send_interactions = vec![
+            SendInteraction::EnqueuedInput(0),
+            SendInteraction::FinishedEpoch(1),
+            SendInteraction::EnqueuedInput(1),
+        ];
+        test_react(block, rollup_status, input_timestamps, send_interactions)
+            .await;
     }
 }

--- a/offchain/dispatcher/src/drivers/mock.rs
+++ b/offchain/dispatcher/src/drivers/mock.rs
@@ -199,9 +199,17 @@ impl Broker {
     }
 
     pub fn assert_send_interactions(&self, expected: Vec<SendInteraction>) {
-        assert_eq!(self.send_interactions_len(), expected.len());
+        assert_eq!(
+            self.send_interactions_len(),
+            expected.len(),
+            "{:?}",
+            self.send_interactions
+        );
+        println!("Send interactions:");
         for (i, expected) in expected.iter().enumerate() {
-            assert_eq!(self.get_send_interaction(i), *expected);
+            let send_interaction = self.get_send_interaction(i);
+            println!("{:?} - {:?}", send_interaction, expected);
+            assert_eq!(send_interaction, *expected);
         }
     }
 }


### PR DESCRIPTION
Porting the 0.9.1 fix from https://github.com/cartesi/rollups/pull/101