### PR TITLE
offchain: missed updates after adding cargo-machete to CI

### DIFF
--- a/.github/workflows/code_format.yml
+++ b/.github/workflows/code_format.yml
@@ -2,7 +2,9 @@
 name: Format onchain code
 on:
   push:
-    paths: 'onchain/**'
+    paths:
+      - '.github/workflows/code_format.yml'
+      - 'onchain/**'
 jobs:
   onchain:
     runs-on: ubuntu-22.04

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -2,7 +2,9 @@
 name: Check for unused dependencies
 on:
   push:
-    paths: 'offchain/**'
+    paths:
+      - '.github/workflows/dependencies.yml'
+      - 'offchain/**'
 jobs:
   check-offchain-deps:
     runs-on: ubuntu-latest

--- a/offchain/Cargo.lock
+++ b/offchain/Cargo.lock
@@ -1451,7 +1451,6 @@ dependencies = [
  "ethers-signers",
  "futures",
  "http-health-check",
- "hyper",
  "im",
  "rand 0.8.5",
  "redis",
@@ -2669,7 +2668,6 @@ dependencies = [
  "tonic 0.9.2",
  "tonic-build 0.9.2",
  "tracing",
- "tracing-subscriber",
  "uuid 1.3.3",
 ]
 
@@ -3976,8 +3974,6 @@ dependencies = [
 name = "rollups-http-client"
 version = "1.0.0"
 dependencies = [
- "async-trait",
- "hex",
  "hyper",
  "serde",
  "serde_json",


### PR DESCRIPTION
I missed some stuff on #137:

- update Cargo.lock
- add the paths of the actual workflow files to their filters