### PR TITLE
fix(offchain): http server config

### DIFF
--- a/offchain/http-server/src/config.rs
+++ b/offchain/http-server/src/config.rs
@@ -50,11 +50,14 @@ fn add_enabled_arg<S: ToString>(
 ) -> Command {
     let service = service.to_string();
     let name = name.to_string();
-    let id = format!("{}_enabled", name);
     command.arg(
-        Arg::new(id.clone())
-            .long(id.clone())
-            .env(format!("{}_{}", service.to_uppercase(), id.to_uppercase()))
+        Arg::new(format!("{}_ENABLED", name.to_uppercase()))
+            .long(format!("{}-enabled", name))
+            .env(format!(
+                "{}_{}_ENABLED",
+                service.to_uppercase(),
+                name.to_uppercase()
+            ))
             .value_parser(value_parser!(bool))
             .default_value("true"),
     )
@@ -63,7 +66,7 @@ fn add_enabled_arg<S: ToString>(
 fn add_port_arg<S: ToString>(command: Command, service: S) -> Command {
     let service = service.to_string().to_uppercase();
     command.arg(
-        Arg::new("port")
+        Arg::new("PORT")
             .long("http-server-port")
             .env(format!("{}_HTTP_SERVER_PORT", service))
             .value_parser(value_parser!(u16))


### PR DESCRIPTION
The argument name should be uppercase with underscore and the CLI argument should be lowercase with dashes.

How it looked:
```
      --healthcheck_enabled <healthcheck_enabled>
          [env: DISPATCHER_HEALTHCHECK_ENABLED=] [default: true] [possible values: true, false]
      --metrics_enabled <metrics_enabled>
          [env: DISPATCHER_METRICS_ENABLED=] [default: true] [possible values: true, false]
       --http-server-port <port>
          [env: DISPATCHER_HTTP_SERVER_PORT=] [default: 8080]
```

How other arguments look like:
```
      --tx-chain-id <TX_CHAIN_ID>
          Chain ID [env: TX_CHAIN_ID=]
```

How it looks now:
```
      --healthcheck-enabled <HEALTHCHECK_ENABLED>
          [env: DISPATCHER_HEALTHCHECK_ENABLED=] [default: true] [possible values: true, false]
      --metrics-enabled <METRICS_ENABLED>
          [env: DISPATCHER_METRICS_ENABLED=] [default: true] [possible values: true, false]
      --http-server-port <PORT>
          [env: DISPATCHER_HTTP_SERVER_PORT=] [default: 8080]
```