### PR TITLE
Fix `foundry` version for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-d369d2486f85576eec4ca41d277391dfdae21ba7
 
       - name: Install jq
         run: sudo apt update && sudo apt install -y jq


### PR DESCRIPTION
Closes #176