### PR TITLE
ci: avoid pruning untagged images

### DIFF
--- a/.github/workflows/rm-closed-pr-images.yml
+++ b/.github/workflows/rm-closed-pr-images.yml
@@ -28,7 +28,7 @@ jobs:
           organization: cartesi
           container: ${{ matrix.image }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          prune-untagged: true
+          prune-untagged: false
           keep-last: 0
           prune-tags-regexes: |
             ^pr-${{ github.event.number }}$


### PR DESCRIPTION
When a PR is merged, the CI workflow is pruning images that where previously built by other PR.

The image built here: https://github.com/cartesi/rollups/actions/runs/5589515433/jobs/10220088013#step:8:242
Was then pruned here on another unrelated PR was merged: https://github.com/cartesi/rollups/actions/runs/5590997314/jobs/10221472336 

This was the real reason for the error on pulling images, and may not be related to the provenance that was disabled at https://github.com/cartesi/rollups/pull/175