### PR TITLE
ci(offchain): enable provenance for buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,6 @@ jobs:
           targets: deps
           push: true
           project: ${{ vars.DEPOT_PROJECT }}
-          provenance: false
 
       - uses: snok/container-retention-policy@v1
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,4 +69,3 @@ jobs:
           targets: ${{ inputs.target }}
           push: true
           project: ${{ vars.DEPOT_PROJECT }}
-          provenance: false


### PR DESCRIPTION
This reverts commit c6e5790da347f19ee9d18e3372e22eb00ff0ca1e.

---

Since we identified at https://github.com/cartesi/rollups/pull/181 that the problem with the images was caused by the GH action that was pruning more images than it should have, we could safely enable the provenance back.