### PR TITLE
offchain: adjust code to avoid some clippy warnings

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -44,8 +44,8 @@ jobs:
         run: cargo machete .
         continue-on-error: true
 
-      - name: Check format
+      - name: Check code format
         run: cargo fmt --all -- --check
 
       - name: Run linter
-        run: cargo clippy -- -A clippy::module_inception -A clippy::new_ret_no_self
+        run: cargo clippy -- -A clippy::module_inception

--- a/offchain/dispatcher/src/auth.rs
+++ b/offchain/dispatcher/src/auth.rs
@@ -58,14 +58,13 @@ pub struct AuthEnvCLIConfig {
 }
 
 #[derive(Debug, Clone)]
-#[allow(clippy::upper_case_acronyms)]
 pub enum AuthConfig {
     Mnemonic {
         mnemonic: String,
         account_index: Option<u32>,
     },
 
-    AWS {
+    Aws {
         key_id: String,
         region: Region,
     },
@@ -95,7 +94,7 @@ impl AuthConfig {
                 (Some(key_id), Some(region)) => {
                     let region = Region::from_str(&region)
                         .context(InvalidRegionSnafu)?;
-                    Ok(AuthConfig::AWS { key_id, region })
+                    Ok(AuthConfig::Aws { key_id, region })
                 }
             }
         }

--- a/offchain/dispatcher/src/signer/signer.rs
+++ b/offchain/dispatcher/src/signer/signer.rs
@@ -58,7 +58,7 @@ impl ConditionalSigner {
                     .with_chain_id(chain_id);
                 Ok(ConditionalSigner::LocalWallet(wallet))
             }
-            AuthConfig::AWS { key_id, region } => {
+            AuthConfig::Aws { key_id, region } => {
                 AwsSigner::new(key_id, chain_id, region)
                     .await
                     .map(ConditionalSigner::AwsSigner)

--- a/offchain/host-runner/src/controller.rs
+++ b/offchain/host-runner/src/controller.rs
@@ -134,7 +134,7 @@ struct Service {
 impl Service {
     fn new(data: SharedStateData) -> Self {
         Self {
-            state: IdleState::new(data),
+            state: IdleState::create(data),
         }
     }
 
@@ -271,7 +271,7 @@ struct IdleState {
 }
 
 impl IdleState {
-    fn new(data: SharedStateData) -> Box<dyn State> {
+    fn create(data: SharedStateData) -> Box<dyn State> {
         Box::new(Self { data })
     }
 }
@@ -285,7 +285,7 @@ impl State for IdleState {
                 tracing::debug!("received finish request; changing state to fetch request");
                 tracing::debug!("request: {:?}", request);
                 let (_, response_tx) = request.into_inner();
-                Some(FetchRequestState::new(self.data, response_tx))
+                Some(FetchRequestState::create(self.data, response_tx))
             }
             Some(request) = self.data.voucher_rx.recv() => {
                 Service::handle_invalid(request, self, "voucher")
@@ -317,7 +317,7 @@ struct FetchRequestState {
 }
 
 impl FetchRequestState {
-    fn new(
+    fn create(
         data: SharedStateData,
         finish_response_tx: oneshot::Sender<
             Result<RollupRequest, ControllerError>,
@@ -339,7 +339,7 @@ impl State for FetchRequestState {
                 tracing::debug!("fetch request timed out; setting state to idle");
                 let timeout_err = ControllerError::FetchRequestTimeout;
                 send_response(self.finish_response_tx, Err(timeout_err));
-                Some(IdleState::new(self.data))
+                Some(IdleState::create(self.data))
             }
             Some(request) = self.data.inspect_rx.recv() => {
                 tracing::debug!("received inspect request; setting state to inspect");
@@ -347,7 +347,7 @@ impl State for FetchRequestState {
                 let (inspect_request, inspect_response_tx) = request.into_inner();
                 let rollup_request = RollupRequest::InspectState(inspect_request);
                 send_response(self.finish_response_tx, Ok(rollup_request));
-                Some(InspectState::new(self.data, inspect_response_tx))
+                Some(InspectState::create(self.data, inspect_response_tx))
             }
             Some(request) = self.data.advance_rx.recv() => {
                 tracing::debug!("received advance request; setting state to advance");
@@ -355,7 +355,7 @@ impl State for FetchRequestState {
                 let (advance_request, advance_response_tx) = request.into_inner();
                 let rollup_request = RollupRequest::AdvanceState(advance_request);
                 send_response(self.finish_response_tx, Ok(rollup_request));
-                Some(AdvanceState::new(self.data, advance_response_tx))
+                Some(AdvanceState::create(self.data, advance_response_tx))
             }
             Some(request) = self.data.finish_rx.recv() => {
                 tracing::debug!("received finish request; terminating previous finish request");
@@ -363,7 +363,7 @@ impl State for FetchRequestState {
                 let timeout_err = ControllerError::FetchRequestTimeout;
                 send_response(self.finish_response_tx, Err(timeout_err));
                 let (_, response_tx) = request.into_inner();
-                Some(FetchRequestState::new(self.data, response_tx))
+                Some(FetchRequestState::create(self.data, response_tx))
             }
             Some(request) = self.data.voucher_rx.recv() => {
                 Service::handle_invalid(request, self, "voucher")
@@ -396,7 +396,7 @@ struct InspectState {
 }
 
 impl InspectState {
-    fn new(
+    fn create(
         data: SharedStateData,
         inspect_response_tx: oneshot::Sender<InspectResult>,
     ) -> Box<dyn State> {
@@ -422,7 +422,7 @@ impl State for InspectState {
                     FinishStatus::Reject => InspectResult::rejected(self.reports),
                 };
                 send_response(self.inspect_response_tx, result);
-                Some(FetchRequestState::new(self.data, response_tx))
+                Some(FetchRequestState::create(self.data, response_tx))
             }
             Some(request) = self.data.report_rx.recv() => {
                 tracing::debug!("received report request");
@@ -440,7 +440,7 @@ impl State for InspectState {
                 let result = InspectResult::exception(self.reports, exception);
                 send_response(self.inspect_response_tx, result);
                 send_response(exception_response_tx, Ok(()));
-                Some(IdleState::new(self.data))
+                Some(IdleState::create(self.data))
             }
             Some(request) = self.data.voucher_rx.recv() => {
                 Service::handle_invalid(request, self, "voucher")
@@ -469,7 +469,7 @@ struct AdvanceState {
 }
 
 impl AdvanceState {
-    fn new(
+    fn create(
         data: SharedStateData,
         advance_response_tx: oneshot::Sender<AdvanceResult>,
     ) -> Box<dyn State> {
@@ -507,7 +507,7 @@ impl State for AdvanceState {
                     },
                 };
                 send_response(self.advance_response_tx, result);
-                Some(FetchRequestState::new(self.data, response_tx))
+                Some(FetchRequestState::create(self.data, response_tx))
             }
             Some(request) = self.data.voucher_rx.recv() => {
                 tracing::debug!("received voucher request");
@@ -546,7 +546,7 @@ impl State for AdvanceState {
                 );
                 send_response(self.advance_response_tx, result);
                 send_response(exception_response_tx, Ok(()));
-                Some(IdleState::new(self.data))
+                Some(IdleState::create(self.data))
             }
             Some(request) = self.data.shutdown_rx.recv() => {
                 Service::shutdown(request)


### PR DESCRIPTION
I have no strong opinions about the changes made at 2657bd5f to the `State` sub-types to meet [new_ret_no_self](https://rust-lang.github.io/rust-clippy/master/index.html#/new_ret_no_self). We can easily dispense with it and move forward if you prefer.

As stated at https://github.com/cartesi/rollups-node/issues/37#issue-1824961694, we're still going to miss changes to meet  *module_inception*. Also, as mentioned at https://github.com/cartesi/rollups-node/issues/37#issuecomment-1654524395, I see no reason to fix *too_many_arguments* warning.

Closes cartesi/rollups-node#37