### PR TITLE
chore(offchain): bump debian baseimage version to 20230725 release

### DIFF
--- a/offchain/Dockerfile
+++ b/offchain/Dockerfile
@@ -34,7 +34,7 @@ COPY . /usr/src/app
 RUN cargo build --release
 
 # define runtime image
-FROM debian:bookworm-20230612-slim as runtime
+FROM debian:bookworm-20230725-slim as runtime
 RUN addgroup --system --gid 102 cartesi && \
     adduser --system --uid 102 --ingroup cartesi --disabled-login --no-create-home --home /nonexistent --gecos "cartesi user" --shell /bin/false cartesi
 RUN mkdir -p /var/opt/cartesi


### PR DESCRIPTION
See: https://github.com/docker-library/official-images/pull/15095

I wasn't sure about updating the rust baseimage version to 1.71.