### PR TITLE
fix(contracts): use `python-venv` in `gen-proofs`

### DIFF
--- a/onchain/rollups/test/foundry/dapp/helper/Dockerfile
+++ b/onchain/rollups/test/foundry/dapp/helper/Dockerfile
@@ -9,10 +9,13 @@ USER root
 
 # Install system dependencies
 RUN apt-get update && \
-    apt-get install -y wget xxd jq git python3 python3-pip
+    apt-get install -y wget xxd jq git python3 python3-pip python3-venv
+
+# Create Python virtual environment
+RUN python3 -m venv /opt/venv/
 
 # Install Python dependencies
-RUN pip install base64-to-hex-converter==0.4.1
+RUN /opt/venv/bin/pip install base64-to-hex-converter==0.4.1
 
 # Install grpcurl
 RUN export ARCH=$(uname -m | sed 's/aarch64/arm64/') && \

--- a/onchain/rollups/test/foundry/dapp/helper/gen-proofs.sh
+++ b/onchain/rollups/test/foundry/dapp/helper/gen-proofs.sh
@@ -179,5 +179,8 @@ add_inputs
 # Wait for all inputs to be processed
 wait_for_inputs_to_be_processed
 
+# Activate python virtual environment
+source /opt/venv/bin/activate
+
 # Finish epoch
-finish_epoch | python3 -m b64to16 > ./output/finish_epoch_response.json
+finish_epoch | python -m b64to16 > ./output/finish_epoch_response.json


### PR DESCRIPTION
In response to this CI job failing due to `pip`.

https://github.com/cartesi/rollups/actions/runs/5892260921/job/15981644855