### PR TITLE
fix: rollups-deployments in rm-closed-pr-images

### DIFF
--- a/.github/workflows/rm-closed-pr-images.yml
+++ b/.github/workflows/rm-closed-pr-images.yml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         image:
-          - deployments
           - rollups-advance-runner
           - rollups-cli
+          - rollups-deployments
           - rollups-dispatcher
           - rollups-graphql-server
           - rollups-hardhat


### PR DESCRIPTION
We renamed this image but forgot to rename it here.