### PR TITLE
fix(graphql-server): integer coercion in variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed integer coercion when reading variables in GraphQL API
+
 ## [1.0.1] 2023-09-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] 2023-09-11
+
 ### Fixed
 
 - Fixed integer coercion when reading variables in GraphQL API

--- a/offchain/Cargo.lock
+++ b/offchain/Cargo.lock
@@ -242,7 +242,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "advance-runner"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1122,7 +1122,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contracts"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "eth-state-fold-types",
 ]
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "dispatcher"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-server"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "grpc-interfaces"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "prost",
  "tonic",
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "host-runner"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "actix-web",
  "async-trait",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "http-health-check"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "axum",
  "hyper",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "http-server"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "axum",
  "clap",
@@ -2775,7 +2775,7 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexer"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "backoff",
  "clap",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "inspect-server"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "redacted"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "url",
 ]
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "rollups-data"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "backoff",
  "base64 0.21.2",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "rollups-events"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "backoff",
  "base64 0.21.2",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "rollups-http-client"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "hyper",
  "serde",
@@ -4853,7 +4853,7 @@ dependencies = [
 
 [[package]]
 name = "state-server"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "eth-block-history",
  "eth-state-fold",
@@ -5017,7 +5017,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-fixtures"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "backoff",
@@ -5538,7 +5538,7 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "types"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/offchain/Cargo.toml
+++ b/offchain/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 license = "Apache-2.0"
 edition = "2021"
 

--- a/offchain/graphql-server/src/schema/scalar.rs
+++ b/offchain/graphql-server/src/schema/scalar.rs
@@ -121,21 +121,33 @@ impl<'de> serde::de::Visitor<'de> for RollupsGraphQLScalarValueVisitor {
     where
         E: serde::de::Error,
     {
-        Ok(RollupsGraphQLScalarValue::BigInt(value))
+        if value <= i32::max_value() as i64 {
+            self.visit_i32(value as i32)
+        } else {
+            Ok(RollupsGraphQLScalarValue::BigInt(value))
+        }
     }
 
     fn visit_u32<E>(self, value: u32) -> Result<RollupsGraphQLScalarValue, E>
     where
         E: serde::de::Error,
     {
-        self.visit_i32(value as i32)
+        if value <= i32::max_value() as u32 {
+            self.visit_i32(value as i32)
+        } else {
+            self.visit_u64(value as u64)
+        }
     }
 
     fn visit_u64<E>(self, value: u64) -> Result<RollupsGraphQLScalarValue, E>
     where
         E: serde::de::Error,
     {
-        self.visit_i64(value as i64)
+        if value <= i64::MAX as u64 {
+            self.visit_i64(value as i64)
+        } else {
+            Ok(RollupsGraphQLScalarValue::Float(value as f64))
+        }
     }
 
     fn visit_f64<E>(self, value: f64) -> Result<RollupsGraphQLScalarValue, E> {

--- a/offchain/graphql-server/tests/integration.rs
+++ b/offchain/graphql-server/tests/integration.rs
@@ -393,6 +393,18 @@ async fn query_reports() {
 
 #[actix_web::test]
 #[serial_test::serial]
+async fn query_with_variables() {
+    let docker = Cli::default();
+    let test = TestState::setup(&docker).await;
+    test.populate_database().await;
+
+    let body = post_query_request("variables.json").await;
+    assert_from_body(body, "variables.json");
+    test.server.stop().await;
+}
+
+#[actix_web::test]
+#[serial_test::serial]
 async fn query_input() {
     let docker = Cli::default();
     let test = TestState::setup(&docker).await;

--- a/offchain/graphql-server/tests/queries/variables.json
+++ b/offchain/graphql-server/tests/queries/variables.json
@@ -1,0 +1,6 @@
+{
+  "query": "query getInput($inputIndex: Int!) { input(index: $inputIndex) { blockNumber } }",
+  "variables": {
+    "inputIndex": 0
+  }
+}

--- a/offchain/graphql-server/tests/responses/variables.json
+++ b/offchain/graphql-server/tests/responses/variables.json
@@ -1,0 +1,1 @@
+{"data":{"input":{"blockNumber":"0"}}}

--- a/onchain/rollups-cli/package.json
+++ b/onchain/rollups-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cartesi/rollups-cli",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Rollups CLI",
     "main": "dist/cli.js",
     "repository": "https://github.com/cartesi/rollups",

--- a/onchain/rollups/package.json
+++ b/onchain/rollups/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cartesi/rollups",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "scripts": {
         "build": "run-s compile export",
         "clean:ignored": "rimraf artifacts cache coverage deployments/localhost dist generated-src src/types/*",


### PR DESCRIPTION
Without this patch, the integer variables are always interpreted as BigInts.

Fixes https://github.com/cartesi/rollups-node/issues/81